### PR TITLE
Fix broken Lens Manual link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Lens.Converter
 ==============
 
-A client-side NLM to Lens converter. For more info see the [Lens Manual](http://substance.io/#substance/lens_manual/toc/header_6).
+A client-side NLM to Lens converter. For more info see the [Lens Manual](http://lens.substance.io/#lens/manual/toc/header_6).
 
 If you spot any errors or have feedback please create an issue [here](http://github.com/elifesciences/lens/issues).


### PR DESCRIPTION
The manual now lives at http://lens.substance.io/#lens/manual.
